### PR TITLE
make toml parsing backwards compatible to python versions < 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,15 @@
 An optional alternative login interface to the default Magpie user interface
 
 # Requirements
-- Python 3.11 or later
-- [TOML parser](https://pypi.org/project/toml/) (if using Python version 3.10 or lower)
-- [Jinja2](https://pypi.org/project/Jinja2/)
+- Python 3.9 or later
 
 # Build the Interface
 
 To convert the files in the `templates/` directory into the login interface:
 
 1. Install the requirements:
-` python3 -m pip install -r requirements.txt`
-2. Depending on your Python version, install the TOML parser as well
-` python3 -m pip install toml`
-3. Build the HTML files
+`python3 -m pip install -r requirements.txt`
+2. Build the HTML files
 `python3 build.py`
 
 The HTML files can now be found in the `build` directory.  To view them go to `build` and run a basic webserver.  

--- a/build.py
+++ b/build.py
@@ -1,13 +1,22 @@
 import os
 import shutil
 import argparse
-import tomllib
 
 from jinja2 import FileSystemLoader, Environment, select_autoescape
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import toml as tomllib
+    TOML_OPEN_MODE="r"
+else:
+    TOML_OPEN_MODE="rb"
+
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 TEMPLATE_PATH = os.path.join(THIS_DIR, "templates")
 SITE_PATH = os.path.join(TEMPLATE_PATH, "site")
+
 
 def filter_site_templates(template, extensions=("js", "html")):
     abs_filepath = os.path.join(TEMPLATE_PATH, template)
@@ -35,7 +44,7 @@ def build(build_directory, node_registry_url, config_file, clean=False):
         with open(build_destination, "w") as f:
             f.write(env.get_template(template).render(node_registry_url=node_registry_url))
 
-        with open(config_file, "rb") as configfile:
+        with open(config_file, TOML_OPEN_MODE) as configfile:
             config_data = tomllib.load(configfile)
             node_details = config_data["Node-Details"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jinja2==3.1.2
+toml==0.10.2; python_version < "3.11"


### PR DESCRIPTION
`tomllib` was introduced to python in version 3.11. For versions before that we can use the `toml` library as a dependency.

However, one library is not a direct drop in replacement for the other so in order to support both we need to modify the code slightly.