### PR TITLE
Add heading to config.default.toml file to prevent build error

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -1,3 +1,4 @@
+[node_details]
 node_name = "__required"
 node_admin_email = "__required"
 magpie_path = "/magpie"


### PR DESCRIPTION
Added heading to node details section in config.default.toml so the parsing works with no arguments.