### PR TITLE
Add timezone dropdown

### DIFF
--- a/static/css/node-login.css
+++ b/static/css/node-login.css
@@ -2157,7 +2157,7 @@ input:required{
     border-radius: var(--textbox-border-radius);
 }
 
-textarea.required:invalid, .input-invalid:invalid{
+textarea.required:invalid, .input-invalid:invalid, .dropdown-invalid{
     background-color: ivory;
     border: none;
     border-style: solid;
@@ -2170,6 +2170,14 @@ textarea.required:invalid, .input-invalid:invalid{
 textarea:required{
     border: var(--border-black);
     border-radius: var(--textbox-border-radius);
+}
+
+.dropdown-hidden-inputfield{
+    background-color: unset;
+    border: unset;
+    outline: unset;
+    width: 0px;
+    height: 0px;
 }
 
 .required-asterisk:after{

--- a/static/css/node-login.css
+++ b/static/css/node-login.css
@@ -1997,6 +1997,11 @@ dialog {
     align-items: center;
 }
 
+.dropdown-list-overflow-y{
+    max-height: 200px;
+    overflow-y: auto;
+}
+
 .author-parent, .multipoint-parent, .upload-geojson-child, .other-child{
     display: flex;
     flex-direction: column;

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -97,45 +97,38 @@
 
                 <script>
                     document.addEventListener("DOMContentLoaded", function () {
-                        var timezonesWithOffsetsList = [];
-                        var stickiedTimezoneList = ["GMT", "UTC"];
+                        var timezoneSet = new Set();
+                        var timezoneSetArray;
                         var dropdownULElement = document.getElementById("{{ dropdown_default_UL_id }}");
                         var generatedTimezonesList = generateTimezoneWithOffset();
 
                         //Make a new list with only UTC and GMT timezone identifiers
                         generatedTimezonesList.forEach( (generatedTimezoneListItem, generatedTimezoneListIndex) => {
-                            stickiedTimezoneList.forEach( (stickiedTimezone, stickiedTimezoneIndex) => {
-                                if(generatedTimezoneListItem.id === stickiedTimezone || generatedTimezoneListItem.id.includes(stickiedTimezone)){
-                                    timezonesWithOffsetsList.splice(0,0, generatedTimezoneListItem);
-                                }
-                            });
+                           timezoneSet.add(generatedTimezoneListItem.offset);
                         });
 
-                        //Remove 'Etc/' from the timezone identifier name and use it as the dropdown item label
+                        //Sort timezones
+                        timezoneSetArray = [...timezoneSet];
+                        timezoneSetArray.sort();
+
                         //Put the timezone offset as an attribute in the anchor tag.  Use it to select the list item
                         //when filling out the form with server data.
-                        timezonesWithOffsetsList.forEach((timezone, timezoneIndex) => {
+                        timezoneSetArray.forEach( (timezoneSetArrayItem, timezoneSetArrayIndex) => {
                             var timezoneName = "";
                             var dropdownLIElement = document.createElement("li");
                             var dropdownAnchorElement = document.createElement("a");
-                            var dropdownAnchorID = "{{ dropdown_default_UL_id }}" + "_" + timezone.id.replace("/","_");
+                            var dropdownAnchorID = "{{ dropdown_default_UL_id }}" + "_" + timezoneSetArrayItem;
+                            var timezoneOffsetArray = timezoneSetArrayItem.split("GMT");
+                            var timezoneOffset = timezoneOffsetArray[1];
 
-                            if(timezone.id.includes("Etc/")){
-                                timezoneName =  timezone.id.replace("Etc/", "");
-                            }
-                            else if(timezone.id.includes("_")){
-                               timezoneName =  timezone.id.replaceAll("_", " ");
-                            }
-                            else{
-                                timezoneName = timezone.id;
-                            }
+                            timezoneName = timezoneSetArrayItem;
 
                             dropdownLIElement.classList.add("dropdown-default-list-item");
 
                             dropdownAnchorElement.classList.add("subtitle-1","dropdown-default-list-item-text");
                             dropdownAnchorElement.setAttribute("role", "button");
-                            dropdownAnchorElement.setAttribute("selected_index", timezone.id);
-                            dropdownAnchorElement.setAttribute("selected_offset", timezone.offset);
+                            dropdownAnchorElement.setAttribute("selected_index", timezoneName);
+                            dropdownAnchorElement.setAttribute("selected_offset", timezoneOffset);
                             dropdownAnchorElement.id = dropdownAnchorID;
                             dropdownAnchorElement.innerText = timezoneName;
                             dropdownAnchorElement.addEventListener('click', function() {

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -48,20 +48,24 @@
 
 
 
-{% if dropdown_type == "geometry_dropdown" or dropdown_type == "model_dropdown" %}
+{% if dropdown_type == "geometry_dropdown" or dropdown_type == "model_dropdown" or dropdown_type == "timezone_dropdown"%}
     <div id="{{ container_id }}" class="dropdown-list-container {{ banner_search_dropdown_class }}">
 
         <div id="{{ dropdown_id }}" class="dropdown">
-        <a id="{{ dropdown_button_id }}" class="btn btn-secondary dropdown-toggle padding-unset dropdown-default-list-button dropdown-default-list-icon" role="button" data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="true" aria-expanded="false">
+            <a id="{{ dropdown_button_id }}" class="btn btn-secondary dropdown-toggle padding-unset dropdown-default-list-button dropdown-default-list-icon" role="button" data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="true" aria-expanded="false">
                 <h6 id="{{ dropdown_button_text_id }}" class="dropdown-list-title margin-unset padding-unset">
                         {{ dropdown_label_text|safe }}
                 </h6>
             </a>
-            <ul id="{{ dropdown_default_UL_id }}" class="dropdown-menu margin-unset padding-unset dropdown-default-list" aria-labelledby="{{ dropdown_button_id }}">
+            {% if dropdown_type == "geometry_dropdown" or dropdown_type == "model_dropdown" %}
+                <ul id="{{ dropdown_default_UL_id }}" class="dropdown-menu margin-unset padding-unset dropdown-default-list" aria-labelledby="{{ dropdown_button_id }}">
+
                 {% set dropdown_list_items = dropdown_library[dropdown_type]["list_items"] %}
+
                 {% for item in dropdown_list_items %}
                     {% set itemIndex = loop.index %}
                     <li class="dropdown-default-list-item">
+
                     {% if dropdown_type == "geometry_dropdown" %}
                         <a id="{{ item["item_id"] }}" class="subtitle-1 dropdown-default-list-item-text" role="button" selected_index="{{ itemIndex }}" onclick="geoPolygon2({{ itemIndex }})">
                             {{ item["item_label"]|safe }}
@@ -85,6 +89,62 @@
                     </script>
 
                 {% endfor %}
+
+             {% endif %}
+
+            {% if dropdown_type == "timezone_dropdown" %}
+                <ul id="{{ dropdown_default_UL_id }}" class="dropdown-menu margin-unset padding-unset dropdown-default-list dropdown-list-overflow-y" aria-labelledby="{{ dropdown_button_id }}">
+
+                <script>
+                    document.addEventListener("DOMContentLoaded", function () {
+                        var stickiedTimezoneList = ["GMT", "UTC"];
+                        var timezoneList = Intl.supportedValuesOf("timeZone");
+                        var dropdownULElement = document.getElementById("{{ dropdown_default_UL_id }}");
+
+                        timezoneList.forEach( (timezoneListItem, timezoneListIndex) => {
+                            stickiedTimezoneList.forEach( (stickiedTimezone, stickiedTimezoneIndex) => {
+                                if(timezoneListItem === stickiedTimezone || timezoneListItem.includes(stickiedTimezone)){
+                                    timezoneList.splice(0,0, timezoneListItem);
+                                    timezoneList.splice(timezoneListIndex + 1,1);
+                                }
+                            });
+                        });
+
+                        timezoneList.forEach((timezone, timezoneIndex) => {
+                            var timezoneName = "";
+                            var dropdownLIElement = document.createElement("li");
+                            var dropdownAnchorElement = document.createElement("a");
+                            var dropdownAnchorID = "{{ dropdown_default_UL_id }}" + "_" + timezone.replace("/","_");
+
+                            if(timezone.includes("Etc/")){
+                                timezoneName =  timezone.replace("Etc/", "");
+                            }
+                            else if(timezone.includes("_")){
+                               timezoneName =  timezone.replaceAll("_", " ");
+                            }
+                            else{
+                                timezoneName = timezone;
+                            }
+
+                            dropdownLIElement.classList.add("dropdown-default-list-item");
+
+                            dropdownAnchorElement.classList.add("subtitle-1","dropdown-default-list-item-text");
+                            dropdownAnchorElement.setAttribute("role", "button");
+                            dropdownAnchorElement.setAttribute("selected_index", timezone);
+                            dropdownAnchorElement.id = dropdownAnchorID;
+                            dropdownAnchorElement.innerText = timezoneName;
+                            dropdownAnchorElement.addEventListener('click', function() {
+                                replaceListItem("{{ dropdown_button_text_id }}", dropdownAnchorID);
+                                applyTimezoneToCalendar(timezone);
+                            });
+
+                            dropdownLIElement.appendChild(dropdownAnchorElement);
+                            dropdownULElement.appendChild(dropdownLIElement);
+                        });
+                    });
+
+                </script>
+            {% endif %}
 
             </ul>
         </div>

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -97,7 +97,7 @@
 
                 <script>
                     document.addEventListener("DOMContentLoaded", function () {
-                        generateTimezoneDropdownListItems("{{ dropdown_default_UL_id }}", "{{ dropdown_button_text_id }}");
+                        generateTimezoneDropdownListItems("{{ container_id }}", "{{ dropdown_default_UL_id }}", "{{ dropdown_button_text_id }}");
                     });
                 </script>
             {% endif %}

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -97,45 +97,49 @@
 
                 <script>
                     document.addEventListener("DOMContentLoaded", function () {
+                        var timezonesWithOffsetsList = [];
                         var stickiedTimezoneList = ["GMT", "UTC"];
-                        var timezoneList = Intl.supportedValuesOf("timeZone");
                         var dropdownULElement = document.getElementById("{{ dropdown_default_UL_id }}");
+                        var generatedTimezonesList = generateTimezoneWithOffset();
 
-                        timezoneList.forEach( (timezoneListItem, timezoneListIndex) => {
+                        //Make a new list with only UTC and GMT timezone identifiers
+                        generatedTimezonesList.forEach( (generatedTimezoneListItem, generatedTimezoneListIndex) => {
                             stickiedTimezoneList.forEach( (stickiedTimezone, stickiedTimezoneIndex) => {
-                                if(timezoneListItem === stickiedTimezone || timezoneListItem.includes(stickiedTimezone)){
-                                    timezoneList.splice(0,0, timezoneListItem);
-                                    timezoneList.splice(timezoneListIndex + 1,1);
+                                if(generatedTimezoneListItem.id === stickiedTimezone || generatedTimezoneListItem.id.includes(stickiedTimezone)){
+                                    timezonesWithOffsetsList.splice(0,0, generatedTimezoneListItem);
                                 }
                             });
                         });
 
-                        timezoneList.forEach((timezone, timezoneIndex) => {
+                        //Remove 'Etc/' from the timezone identifier name and use it as the dropdown item label
+                        //Put the timezone offset as an attribute in the anchor tag.  Use it to select the list item
+                        //when filling out the form with server data.
+                        timezonesWithOffsetsList.forEach((timezone, timezoneIndex) => {
                             var timezoneName = "";
                             var dropdownLIElement = document.createElement("li");
                             var dropdownAnchorElement = document.createElement("a");
-                            var dropdownAnchorID = "{{ dropdown_default_UL_id }}" + "_" + timezone.replace("/","_");
+                            var dropdownAnchorID = "{{ dropdown_default_UL_id }}" + "_" + timezone.id.replace("/","_");
 
-                            if(timezone.includes("Etc/")){
-                                timezoneName =  timezone.replace("Etc/", "");
+                            if(timezone.id.includes("Etc/")){
+                                timezoneName =  timezone.id.replace("Etc/", "");
                             }
-                            else if(timezone.includes("_")){
-                               timezoneName =  timezone.replaceAll("_", " ");
+                            else if(timezone.id.includes("_")){
+                               timezoneName =  timezone.id.replaceAll("_", " ");
                             }
                             else{
-                                timezoneName = timezone;
+                                timezoneName = timezone.id;
                             }
 
                             dropdownLIElement.classList.add("dropdown-default-list-item");
 
                             dropdownAnchorElement.classList.add("subtitle-1","dropdown-default-list-item-text");
                             dropdownAnchorElement.setAttribute("role", "button");
-                            dropdownAnchorElement.setAttribute("selected_index", timezone);
+                            dropdownAnchorElement.setAttribute("selected_index", timezone.id);
+                            dropdownAnchorElement.setAttribute("selected_offset", timezone.offset);
                             dropdownAnchorElement.id = dropdownAnchorID;
                             dropdownAnchorElement.innerText = timezoneName;
                             dropdownAnchorElement.addEventListener('click', function() {
                                 replaceListItem("{{ dropdown_button_text_id }}", dropdownAnchorID);
-                                addTimezoneToSelectedTime(timezone);
                             });
 
                             dropdownLIElement.appendChild(dropdownAnchorElement);

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -67,13 +67,13 @@
                     <li class="dropdown-default-list-item">
 
                     {% if dropdown_type == "geometry_dropdown" %}
-                        <a id="{{ item["item_id"] }}" class="subtitle-1 dropdown-default-list-item-text" role="button" selected_index="{{ itemIndex }}" onclick="geoPolygon2({{ itemIndex }})">
+                        <a id="{{ item["item_id"] }}" class="subtitle-1 dropdown-default-list-item-text" role="button" data-selected_index="{{ itemIndex }}" onclick="geoPolygon2({{ itemIndex }})">
                             {{ item["item_label"]|safe }}
                         </a>
                     {% endif %}
 
                     {% if dropdown_type == "model_dropdown" %}
-                        <a id="{{ item["item_id"] }}" class="subtitle-1 dropdown-default-list-item-text" role="button" selected_index="{{ itemIndex }}"  selected_value="{{ item["item_label"].lower() }}">
+                        <a id="{{ item["item_id"] }}" class="subtitle-1 dropdown-default-list-item-text" role="button" data-selected_index="{{ itemIndex }}"  selected_value="{{ item["item_label"].lower() }}">
                             {{ item["item_label"]|safe }}
                         </a>
                     {% endif %}
@@ -97,49 +97,8 @@
 
                 <script>
                     document.addEventListener("DOMContentLoaded", function () {
-                        var timezoneSet = new Set();
-                        var timezoneSetArray;
-                        var dropdownULElement = document.getElementById("{{ dropdown_default_UL_id }}");
-                        var generatedTimezonesList = generateTimezoneWithOffset();
-
-                        //Make a new list with only UTC and GMT timezone identifiers
-                        generatedTimezonesList.forEach( (generatedTimezoneListItem, generatedTimezoneListIndex) => {
-                           timezoneSet.add(generatedTimezoneListItem.offset);
-                        });
-
-                        //Sort timezones
-                        timezoneSetArray = [...timezoneSet];
-                        timezoneSetArray.sort();
-
-                        //Put the timezone offset as an attribute in the anchor tag.  Use it to select the list item
-                        //when filling out the form with server data.
-                        timezoneSetArray.forEach( (timezoneSetArrayItem, timezoneSetArrayIndex) => {
-                            var timezoneName = "";
-                            var dropdownLIElement = document.createElement("li");
-                            var dropdownAnchorElement = document.createElement("a");
-                            var dropdownAnchorID = "{{ dropdown_default_UL_id }}" + "_" + timezoneSetArrayItem;
-                            var timezoneOffsetArray = timezoneSetArrayItem.split("GMT");
-                            var timezoneOffset = timezoneOffsetArray[1];
-
-                            timezoneName = timezoneSetArrayItem;
-
-                            dropdownLIElement.classList.add("dropdown-default-list-item");
-
-                            dropdownAnchorElement.classList.add("subtitle-1","dropdown-default-list-item-text");
-                            dropdownAnchorElement.setAttribute("role", "button");
-                            dropdownAnchorElement.setAttribute("selected_index", timezoneName);
-                            dropdownAnchorElement.setAttribute("selected_offset", timezoneOffset);
-                            dropdownAnchorElement.id = dropdownAnchorID;
-                            dropdownAnchorElement.innerText = timezoneName;
-                            dropdownAnchorElement.addEventListener('click', function() {
-                                replaceListItem("{{ dropdown_button_text_id }}", dropdownAnchorID);
-                            });
-
-                            dropdownLIElement.appendChild(dropdownAnchorElement);
-                            dropdownULElement.appendChild(dropdownLIElement);
-                        });
+                        generateTimezoneDropdownListItems();
                     });
-
                 </script>
             {% endif %}
 

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -135,7 +135,7 @@
                             dropdownAnchorElement.innerText = timezoneName;
                             dropdownAnchorElement.addEventListener('click', function() {
                                 replaceListItem("{{ dropdown_button_text_id }}", dropdownAnchorID);
-                                applyTimezoneToCalendar(timezone);
+                                addTimezoneToSelectedTime(timezone);
                             });
 
                             dropdownLIElement.appendChild(dropdownAnchorElement);

--- a/templates/partials/dropdown-publish.html
+++ b/templates/partials/dropdown-publish.html
@@ -97,7 +97,7 @@
 
                 <script>
                     document.addEventListener("DOMContentLoaded", function () {
-                        generateTimezoneDropdownListItems();
+                        generateTimezoneDropdownListItems("{{ dropdown_default_UL_id }}", "{{ dropdown_button_text_id }}");
                     });
                 </script>
             {% endif %}

--- a/templates/site/js/dataproduct-form.js
+++ b/templates/site/js/dataproduct-form.js
@@ -629,7 +629,7 @@ function initializeModelDropdown(dropdownID){
     var anchorTags = dropdown.querySelectorAll("li > a");
 
     anchorTags.forEach((tag) => {
-        var selectedIndex = tag.getAttribute("selected_index");
+        var selectedIndex = tag.getAttribute("data-selected_index");
         var selectedValue = tag.getAttribute("selected_value");
 
         tag.addEventListener("click", function (){
@@ -706,7 +706,7 @@ function addModel(divElementID) {
     templateDropdownButtonText.id = "dropdownListModelButtonText_" + autindex;
 
     templateDropdownULItemAnchorLinks.forEach((anchorTag) => {
-        var anchorSelectedIndex = anchorTag.getAttribute("selected_index");
+        var anchorSelectedIndex = anchorTag.getAttribute("data-selected_index");
         var anchorSelectedValue = anchorTag.getAttribute("selected_value");
 
         var anchorID = "model" + anchorSelectedValue.charAt(0).toUpperCase() + anchorSelectedValue.slice(1) + "_" + autindex;
@@ -870,7 +870,7 @@ function showHideModelInput(dropdownItemIndex, dropdownItemName, dropdownIndex){
     var dropdownListModelButtonText = document.getElementById("dropdownListModelButtonText_" + dropdownIndex);
 
 
-    dropdownListModelButtonText.setAttribute("selected_index", dropdownItemIndex);
+    dropdownListModelButtonText.setAttribute("data-selected_index", dropdownItemIndex);
 
     switch (dropdownItemIndex){
         case 1:
@@ -902,12 +902,7 @@ function addTimezoneToSelectedTime(timezoneOffset){
     var endDate = endDateElement._flatpickr.selectedDates[0];
 
     //Format the date using the timezone offset value/identifier, not the timezone identifier name
-    var dateFormatter = new Intl.DateTimeFormat("en-GB", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
+    var dateFormatter = new Intl.DateTimeFormat("en-US", {
         timeZoneName: "longOffset",
         timeZone: timezoneOffset,
     });
@@ -919,14 +914,17 @@ function addTimezoneToSelectedTime(timezoneOffset){
     var endDateConvertedUTCPreserveTime = new Date(endDate - endDate.getTimezoneOffset() * 60000).toISOString();
     var endDateConvertedUTCPreserveTimeArray = endDateConvertedUTCPreserveTime.split("Z");
 
-    var formattedStartDate = dateFormatter.format(startDate);
-    var formattedEndDate = dateFormatter.format(endDate);
+    var formattedStartDateParts = dateFormatter.formatToParts(startDate);
+    var formattedEndDateParts = dateFormatter.formatToParts(endDate);
 
-    var startDateSplitTimezoneArray = formattedStartDate.split("GMT");
+    const formattedStartDateOffsetPart = formattedStartDateParts.find(part => part.type === 'timeZoneName');
+    const formattedEndDateOffsetPart = formattedEndDateParts.find(part => part.type === 'timeZoneName');
+
+    var startDateSplitTimezoneArray = formattedStartDateOffsetPart.value.split("GMT");
     var startDateTimezoneOffset = startDateSplitTimezoneArray[1];
     var serverStartDate = startDateConvertedUTCPreserveTimeArray[0] + startDateTimezoneOffset;
 
-    var endDateSplitTimezoneArray = formattedEndDate.split("GMT");
+    var endDateSplitTimezoneArray = formattedEndDateOffsetPart.value.split("GMT");
     var endDateTimezoneOffset = endDateSplitTimezoneArray[1];
     var serverEndDate = endDateConvertedUTCPreserveTimeArray[0] + endDateTimezoneOffset;
 
@@ -1058,7 +1056,7 @@ async function submitForm(){
     var coordinateArray = [];
     var geometryGeoJSONBBox;
     var timezoneDropdownLabel = document.getElementById("dropdownListTemporalStartButtonText");
-    var timezoneOffset = timezoneDropdownLabel.getAttribute("selected_offset");
+    var timezoneOffset = timezoneDropdownLabel.getAttribute("data-selected_offset");
     var textareaMetadataVariables = document.getElementById("metadata_variables");
     var textareaMetadataArray = [];
     var linkedPathField = document.getElementById("linked_path");
@@ -1070,7 +1068,7 @@ async function submitForm(){
     var metadataModelObjectArray = [];
     var otherMetadataObject = {};
     var geometryDropdownButtonTitle = document.getElementById("dropdownListDefaultButtonText");
-    var geometrySelection = parseInt(geometryDropdownButtonTitle.getAttribute("selected_index"));
+    var geometrySelection = parseInt(geometryDropdownButtonTitle.getAttribute("data-selected_index"));
     var geometryDropdownContent;
 
     if(descriptionInput.value.trim() == ""){
@@ -1230,8 +1228,8 @@ async function submitForm(){
         metadataModelObject["rel"] = selectedModelValue;
 
 
-        if(dropdownButton.getAttribute("selected_index") != null){
-            selectedModelIndex = parseInt(dropdownButton.getAttribute("selected_index"));
+        if(dropdownButton.getAttribute("data-selected_index") != null){
+            selectedModelIndex = parseInt(dropdownButton.getAttribute("data-selected_index"));
 
             if(metadataModelHREF.value.trim() == ""){
 

--- a/templates/site/js/dataproduct-form.js
+++ b/templates/site/js/dataproduct-form.js
@@ -896,6 +896,10 @@ function showHideModelInput(dropdownItemIndex, dropdownItemName, dropdownIndex){
 //Add selected timezone to the selected start date time and end date time without converting the date time value
 //Returns date time in ISO format with the selected timezone offset
 function addTimezoneToSelectedTime(timezoneOffset){
+    var startDateTimezoneOffset;
+    var startDateSplitTimezoneArray;
+    var endDateSplitTimezoneArray;
+    var endDateTimezoneOffset;
     var startDateElement = document.getElementById("metadata_start_date");
     var endDateElement = document.getElementById("metadata_end_date");
     var startDate = startDateElement._flatpickr.selectedDates[0];
@@ -920,12 +924,21 @@ function addTimezoneToSelectedTime(timezoneOffset){
     const formattedStartDateOffsetPart = formattedStartDateParts.find(part => part.type === 'timeZoneName');
     const formattedEndDateOffsetPart = formattedEndDateParts.find(part => part.type === 'timeZoneName');
 
-    var startDateSplitTimezoneArray = formattedStartDateOffsetPart.value.split("GMT");
-    var startDateTimezoneOffset = startDateSplitTimezoneArray[1];
-    var serverStartDate = startDateConvertedUTCPreserveTimeArray[0] + startDateTimezoneOffset;
+    if(formattedStartDateOffsetPart.value === "GMT"){
+        startDateTimezoneOffset = "+00:00";
+    }else{
+        startDateSplitTimezoneArray = formattedStartDateOffsetPart.value.split("GMT");
+        startDateTimezoneOffset = startDateSplitTimezoneArray[1];
+    }
 
-    var endDateSplitTimezoneArray = formattedEndDateOffsetPart.value.split("GMT");
-    var endDateTimezoneOffset = endDateSplitTimezoneArray[1];
+    if(formattedEndDateOffsetPart.value === "GMT"){
+        endDateTimezoneOffset = "+00:00";
+    }else{
+        endDateSplitTimezoneArray = formattedEndDateOffsetPart.value.split("GMT");
+        endDateTimezoneOffset = endDateSplitTimezoneArray[1];
+    }
+
+    var serverStartDate = startDateConvertedUTCPreserveTimeArray[0] + startDateTimezoneOffset;
     var serverEndDate = endDateConvertedUTCPreserveTimeArray[0] + endDateTimezoneOffset;
 
     var timezoneArray = [serverStartDate, serverEndDate];
@@ -950,7 +963,11 @@ function generateTimezoneWithOffset(){
         const offsetPart = parts.find(part => part.type === 'timeZoneName');
 
         if(offsetPart){
-            offset = offsetPart.value;
+            if(offsetPart.value == "GMT"){
+                offset = "GMT+00:00";
+            }else{
+                offset = offsetPart.value;
+            }
         }
 
         var timezoneOffsets = {

--- a/templates/site/js/dataproduct-form.js
+++ b/templates/site/js/dataproduct-form.js
@@ -1072,6 +1072,8 @@ async function submitForm(){
     var visibleGeometry;
     var coordinateArray = [];
     var geometryGeoJSONBBox;
+    var timezoneDropdownContainer =  document.getElementById("temporalStartDropdownContainer");
+    var timezoneHiddenInput = document.getElementById("hiddenTimezoneDropdown");
     var timezoneDropdownLabel = document.getElementById("dropdownListTemporalStartButtonText");
     var timezoneOffset = timezoneDropdownLabel.getAttribute("data-selected_offset");
     var textareaMetadataVariables = document.getElementById("metadata_variables");
@@ -1445,7 +1447,16 @@ async function submitForm(){
 
     /*Add Metadata date input to submitObject*/
     submitObject["temporal"] = [];
-    submitObject["temporal"] = addTimezoneToSelectedTime(timezoneOffset);
+    if(timezoneOffset){
+        timezoneDropdownContainer.classList.remove("dropdown-invalid");
+        timezoneHiddenInput.setCustomValidity("");
+        submitObject["temporal"] = addTimezoneToSelectedTime(timezoneOffset);
+    }
+    else{
+        timezoneDropdownContainer.classList.add("dropdown-invalid");
+        timezoneHiddenInput.setCustomValidity("Timezone needs a value.");
+    }
+
 
     submitObject["user"] = (await  window.session_info).user.user_name;
     submitObject["title"] = titleInput.value.trim();

--- a/templates/site/js/dataproduct-form.js
+++ b/templates/site/js/dataproduct-form.js
@@ -911,15 +911,6 @@ function addTimezoneToSelectedTime(timezone){
         timeZone: timezone,
     });
 
-    console.log("startDate")
-    console.log(startDate)
-
-    console.log("startDate.getTimezoneOffset()")
-    console.log(startDate.getTimezoneOffset())
-
-    console.log("startDate calculate utc")
-    console.log(startDate - startDate.getTimezoneOffset() * 60000);
-
     //Converts the date-time to ISO string with timezone at UTC while preserving the time value.
     var startDateConvertedUTCPreserveTime = new Date(startDate - startDate.getTimezoneOffset() * 60000).toISOString();
     var startDateConvertedUTCPreserveTimeArray = startDateConvertedUTCPreserveTime.split("Z");
@@ -939,10 +930,38 @@ function addTimezoneToSelectedTime(timezone){
     var serverEndDate = endDateConvertedUTCPreserveTimeArray[0] + endDateTimezoneOffset;
 
     var timezoneArray = [serverStartDate, serverEndDate];
-    console.log(timezoneArray)
+
     return timezoneArray;
+}
 
+function generateTimezoneWithOffset(){
+    const timezonesWithOffsetsList = Intl.supportedValuesOf('timeZone').map(timeZone => {
+        // Create a date object to get the offset for a specific point in time
+        const now = new Date();
 
+        // Create a DateTimeFormat object for the specific timezone and locale
+        const formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone: timeZone,
+            timeZoneName: 'longOffset'
+        });
+
+        // Extract the offset from the formatted parts
+        const parts = formatter.formatToParts(now);
+        const offsetPart = parts.find(part => part.type === 'timeZoneName');
+
+        if(offsetPart){
+            offset = offsetPart.value
+        }
+
+        var timezoneOffsets = {
+            id: timeZone,
+            offset: offset
+        }
+
+        return timezoneOffsets;
+    });
+
+    return timezonesWithOffsetsList;
 }
 
 function calendarDatesEqual(checkboxDateEqualID, startDateID, endDateID){

--- a/templates/site/js/dataproduct-retrieve.js
+++ b/templates/site/js/dataproduct-retrieve.js
@@ -1,6 +1,5 @@
 async function populateForm(){
-    //var currentUser = (await  window.session_info).user.user_name;
-    var currentUser = "testuser"
+    var currentUser = (await  window.session_info).user.user_name;
     var queryString = window.location.search;
     var urlParams = new URLSearchParams(queryString);
     var marbleAPIURL;
@@ -153,33 +152,34 @@ async function populateForm(){
 
 
                 /*Fill in Date and Timezone*/
+                var serverTimezoneOffset;
                 var metadataStartDate = document.getElementById("metadata_start_date");
                 var metadataEndDate = document.getElementById("metadata_end_date");
                 var dateEqualCheckbox = document.getElementById("date_make_equal");
                 var timezoneDropdown = document.getElementById("timezoneDropdown");
                 var timezoneAnchorList = timezoneDropdown.querySelectorAll("li>a");
-                var serverTimezoneOffset;
                 var serverStartDate = dataproductJSON.temporal[0];
                 var serverEndDate = dataproductJSON.temporal[1];
                 var indexOfLastColon = serverStartDate.lastIndexOf(":");
-                var offsetIndicator = serverStartDate.charAt(indexOfLastColon - 3);
-                var serverTimezoneArray = serverStartDate.split(offsetIndicator);
+                var offsetIndicator = "";
 
-                if(offsetIndicator == "-"){
-                    serverTimezoneOffset = "GMT" + offsetIndicator +  serverTimezoneArray[3];
+                if(serverEndDate.includes("Z")){
+                    serverTimezoneOffset = "00:00";
                 }else{
-                    serverTimezoneOffset = "GMT" + offsetIndicator +  serverTimezoneArray[1];
+                    offsetIndicator = serverStartDate.charAt(indexOfLastColon - 3);
                 }
 
+                serverTimezoneOffset = "GMT" + offsetIndicator +  serverStartDate.slice(indexOfLastColon - 2, serverStartDate.length);
+
                 timezoneAnchorList.forEach( (anchorTag, anchorTagIndex) => {
-                    var selectedOffset = anchorTag.getAttribute("selected_index");
+                    var selectedOffset = anchorTag.getAttribute("data-selected_index");
                     if(selectedOffset == serverTimezoneOffset){
                         replaceListItem("dropdownListTemporalStartButtonText", anchorTag.id);
                     }
                 });
 
-                metadataStartDate._flatpickr.setDate(serverStartDate.replace("T", " "));
-                metadataEndDate._flatpickr.setDate(serverEndDate.replace("T", " "));
+                metadataStartDate._flatpickr.setDate(serverStartDate);
+                metadataEndDate._flatpickr.setDate(serverEndDate);
 
                 if(dataproductJSON.temporal[0] == dataproductJSON.temporal[1]){
                     dateEqualCheckbox.checked = true;
@@ -224,7 +224,7 @@ async function populateForm(){
                         else if(link.rel == "model"){
                             selectedDropdownItemID = "modelModel_" + rowIndex;
                             selectedDropdownItem = document.getElementById(selectedDropdownItemID);
-                            selectedIndex = selectedDropdownItem.getAttribute("selected_index");
+                            selectedIndex = selectedDropdownItem.getAttribute("data-selected_index");
                             selectedValue = selectedDropdownItem.getAttribute("selected_value");
 
                             replaceListItem(dropdownItemTextID, selectedDropdownItemID);
@@ -236,7 +236,7 @@ async function populateForm(){
                         else{
                             selectedDropdownItemID = "modelOther_" + rowIndex;
                             selectedDropdownItem = document.getElementById(selectedDropdownItemID);
-                            selectedIndex = selectedDropdownItem.getAttribute("selected_index");
+                            selectedIndex = selectedDropdownItem.getAttribute("data-selected_index");
                             selectedValue = selectedDropdownItem.getAttribute("selected_value");
 
                             replaceListItem(dropdownItemTextID, selectedDropdownItemID);

--- a/templates/site/js/dataproduct-retrieve.js
+++ b/templates/site/js/dataproduct-retrieve.js
@@ -1,5 +1,6 @@
 async function populateForm(){
-    var currentUser = (await  window.session_info).user.user_name;
+    //var currentUser = (await  window.session_info).user.user_name;
+    var currentUser = "testuser"
     var queryString = window.location.search;
     var urlParams = new URLSearchParams(queryString);
     var marbleAPIURL;
@@ -157,6 +158,31 @@ async function populateForm(){
                 var dateEqualCheckbox = document.getElementById("date_make_equal");
                 var firstDateString = new Date(dataproductJSON.temporal[0]);
                 var secondDateString = new Date(dataproductJSON.temporal[1]);
+
+
+
+                console.log("firstDateString")
+                console.log(firstDateString)
+
+
+                console.log("firstDateString.getTimezoneOffset()")
+                console.log(firstDateString.getTimezoneOffset())
+                /*
+                var dateFormatter = new Intl.DateTimeFormat("en-GB", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    timeZoneName: "longOffset",
+                    timeZone: timezone,
+                });*/
+
+                var convertedFirstDate = new Date(firstDateString + firstDateString.getTimezoneOffset() * 60000).toISOString()
+
+
+                console.log("convertedFirstDate")
+                console.log(convertedFirstDate)
 
                 metadataStartDate._flatpickr.setDate(firstDateString);
                 metadataEndDate._flatpickr.setDate(secondDateString);

--- a/templates/site/js/dataproduct-retrieve.js
+++ b/templates/site/js/dataproduct-retrieve.js
@@ -172,7 +172,7 @@ async function populateForm(){
                 }
 
                 timezoneAnchorList.forEach( (anchorTag, anchorTagIndex) => {
-                    var selectedOffset = anchorTag.getAttribute("selected_offset");
+                    var selectedOffset = anchorTag.getAttribute("selected_index");
                     if(selectedOffset == serverTimezoneOffset){
                         replaceListItem("dropdownListTemporalStartButtonText", anchorTag.id);
                     }

--- a/templates/site/js/dataproduct-retrieve.js
+++ b/templates/site/js/dataproduct-retrieve.js
@@ -152,44 +152,40 @@ async function populateForm(){
 
 
 
-                /*Fill in Date*/
+                /*Fill in Date and Timezone*/
                 var metadataStartDate = document.getElementById("metadata_start_date");
                 var metadataEndDate = document.getElementById("metadata_end_date");
                 var dateEqualCheckbox = document.getElementById("date_make_equal");
-                var firstDateString = new Date(dataproductJSON.temporal[0]);
-                var secondDateString = new Date(dataproductJSON.temporal[1]);
+                var timezoneDropdown = document.getElementById("timezoneDropdown");
+                var timezoneAnchorList = timezoneDropdown.querySelectorAll("li>a");
+                var serverTimezoneOffset;
+                var serverStartDate = dataproductJSON.temporal[0];
+                var serverEndDate = dataproductJSON.temporal[1];
+                var indexOfLastColon = serverStartDate.lastIndexOf(":");
+                var offsetIndicator = serverStartDate.charAt(indexOfLastColon - 3);
+                var serverTimezoneArray = serverStartDate.split(offsetIndicator);
 
+                if(offsetIndicator == "-"){
+                    serverTimezoneOffset = "GMT" + offsetIndicator +  serverTimezoneArray[3];
+                }else{
+                    serverTimezoneOffset = "GMT" + offsetIndicator +  serverTimezoneArray[1];
+                }
 
+                timezoneAnchorList.forEach( (anchorTag, anchorTagIndex) => {
+                    var selectedOffset = anchorTag.getAttribute("selected_offset");
+                    if(selectedOffset == serverTimezoneOffset){
+                        replaceListItem("dropdownListTemporalStartButtonText", anchorTag.id);
+                    }
+                });
 
-                console.log("firstDateString")
-                console.log(firstDateString)
-
-
-                console.log("firstDateString.getTimezoneOffset()")
-                console.log(firstDateString.getTimezoneOffset())
-                /*
-                var dateFormatter = new Intl.DateTimeFormat("en-GB", {
-                    year: "numeric",
-                    month: "2-digit",
-                    day: "2-digit",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    timeZoneName: "longOffset",
-                    timeZone: timezone,
-                });*/
-
-                var convertedFirstDate = new Date(firstDateString + firstDateString.getTimezoneOffset() * 60000).toISOString()
-
-
-                console.log("convertedFirstDate")
-                console.log(convertedFirstDate)
-
-                metadataStartDate._flatpickr.setDate(firstDateString);
-                metadataEndDate._flatpickr.setDate(secondDateString);
+                metadataStartDate._flatpickr.setDate(serverStartDate.replace("T", " "));
+                metadataEndDate._flatpickr.setDate(serverEndDate.replace("T", " "));
 
                 if(dataproductJSON.temporal[0] == dataproductJSON.temporal[1]){
                     dateEqualCheckbox.checked = true;
                 }
+
+
 
                 /*Fill in Variables*/
                 var variablesText = "";

--- a/templates/site/js/dropdown-list.js
+++ b/templates/site/js/dropdown-list.js
@@ -3,10 +3,16 @@ function replaceListItem(titleItemID, selectedItemID){
     var secondItem = document.getElementById(selectedItemID);
     var selectedID;
     var selectedIndex;
+    var selectedOffset;
 
     firstItem.innerHTML = secondItem.innerHTML;
     selectedID = secondItem.id;
     selectedIndex = secondItem.getAttribute("selected_index");
     firstItem.setAttribute("selected_index", selectedIndex);
     firstItem.setAttribute("selected_id", selectedID);
+
+    if(secondItem.hasAttribute("selected_offset")){
+        selectedOffset = secondItem.getAttribute("selected_offset");
+        firstItem.setAttribute("selected_offset", selectedOffset);
+    }
 }

--- a/templates/site/js/dropdown-list.js
+++ b/templates/site/js/dropdown-list.js
@@ -17,11 +17,21 @@ function replaceListItem(titleItemID, selectedItemID){
     }
 }
 
-function generateTimezoneDropdownListItems(dropdownID, dropdownButtonTextID){
+function generateTimezoneDropdownListItems(dropdownContainerID, dropdownID, dropdownButtonTextID){
     var timezoneSet = new Set();
     var timezoneSetArray;
+    var dropdownTitleLabel = document.getElementById(dropdownButtonTextID);
     var dropdownULElement = document.getElementById(dropdownID);
     var generatedTimezonesList = generateTimezoneWithOffset();
+    var dropdownContainer = document.getElementById(dropdownContainerID);
+    var hiddenSelectDropdownInputField = document.createElement("input");
+
+    dropdownTitleLabel.setAttribute("data-selected_offset", "");
+
+    hiddenSelectDropdownInputField.id = "hiddenTimezoneDropdown";
+    hiddenSelectDropdownInputField.classList.add("dropdown-hidden-inputfield");
+
+    dropdownContainer.appendChild(hiddenSelectDropdownInputField);
 
     //Make a new list with only UTC and GMT timezone identifiers
     generatedTimezonesList.forEach( (generatedTimezoneListItem) => {

--- a/templates/site/js/dropdown-list.js
+++ b/templates/site/js/dropdown-list.js
@@ -7,12 +7,62 @@ function replaceListItem(titleItemID, selectedItemID){
 
     firstItem.innerHTML = secondItem.innerHTML;
     selectedID = secondItem.id;
-    selectedIndex = secondItem.getAttribute("selected_index");
-    firstItem.setAttribute("selected_index", selectedIndex);
+    selectedIndex = secondItem.getAttribute("data-selected_index");
+    firstItem.setAttribute("data-selected_index", selectedIndex);
     firstItem.setAttribute("selected_id", selectedID);
 
-    if(secondItem.hasAttribute("selected_offset")){
-        selectedOffset = secondItem.getAttribute("selected_offset");
-        firstItem.setAttribute("selected_offset", selectedOffset);
+    if(secondItem.hasAttribute("data-selected_offset")){
+        selectedOffset = secondItem.getAttribute("data-selected_offset");
+        firstItem.setAttribute("data-selected_offset", selectedOffset);
     }
+}
+
+function generateTimezoneDropdownListItems(dropdownID, dropdownButtonTextID){
+    var timezoneSet = new Set();
+    var timezoneSetArray;
+    var dropdownULElement = document.getElementById(dropdownID);
+    var generatedTimezonesList = generateTimezoneWithOffset();
+
+    //Make a new list with only UTC and GMT timezone identifiers
+    generatedTimezonesList.forEach( (generatedTimezoneListItem) => {
+       timezoneSet.add(generatedTimezoneListItem.offset);
+    });
+
+    //Sort timezones
+    timezoneSetArray = [...timezoneSet];
+    timezoneSetArray.sort();
+
+    //Put the timezone offset as an attribute in the anchor tag.  Use it to select the list item
+    //when filling out the form with server data.
+    timezoneSetArray.forEach( (timezoneSetArrayItem) => {
+        var timezoneLabel;
+        var timezoneName = timezoneSetArrayItem;
+        var dropdownLIElement = document.createElement("li");
+        var dropdownAnchorElement = document.createElement("a");
+        var dropdownAnchorID = dropdownID + "_" + timezoneSetArrayItem;
+        var timezoneOffsetArray = timezoneSetArrayItem.split("GMT");
+        var timezoneOffset = timezoneOffsetArray[1];
+
+        if(timezoneOffset == "+00:00"){
+            timezoneLabel = "GMT";
+        }
+        else{
+            timezoneLabel = timezoneSetArrayItem;
+        }
+
+        dropdownLIElement.classList.add("dropdown-default-list-item");
+
+        dropdownAnchorElement.classList.add("subtitle-1","dropdown-default-list-item-text");
+        dropdownAnchorElement.setAttribute("role", "button");
+        dropdownAnchorElement.setAttribute("data-selected_index", timezoneName);
+        dropdownAnchorElement.setAttribute("data-selected_offset", timezoneOffset);
+        dropdownAnchorElement.id = dropdownAnchorID;
+        dropdownAnchorElement.innerText = timezoneLabel;
+        dropdownAnchorElement.addEventListener('click', function() {
+            replaceListItem(dropdownButtonTextID, dropdownAnchorID);
+        });
+
+        dropdownLIElement.appendChild(dropdownAnchorElement);
+        dropdownULElement.appendChild(dropdownLIElement);
+    });
 }

--- a/templates/site/publish-dataproduct.html
+++ b/templates/site/publish-dataproduct.html
@@ -112,7 +112,6 @@
             <h4> Metadata </h4>
             <hr class="margin-title-underline">
             <h5 class="margin-title"> Temporal Extent</h5>
-            <p>All timestamps will use the local time zone. </p>
             <label for="metadata_start_date" class="subtitle-1 required-asterisk">Start Date (Required)</label>
             <div class="calendar-container">
                 <input id="metadata_start_date" type="datetime-local" name="start_date" class="input-textbox margin-input-field" required/>
@@ -142,6 +141,7 @@
             </div>
 
             <div id="metadata_start_timezone">
+            <label for="timezoneDropdown" class="subtitle-1 margin-input-label required-asterisk">Choose a timezone (Required):</label>
                 {% with %}
                     {% set dropdown_type = "timezone_dropdown" %}
                     {% set banner_search_dropdown_class = "banner-dropdown-list-container"%}

--- a/templates/site/publish-dataproduct.html
+++ b/templates/site/publish-dataproduct.html
@@ -120,6 +120,7 @@
                     <i class="fa-solid fa-calendar-days icon-metadata-calendar"></i>
                 </div>
 
+
             </div>
 
             <label for="metadata_end_date" class="subtitle-1 margin-input-label required-asterisk">End Date (Required)</label>
@@ -128,7 +129,6 @@
                 <div id="metadata_end_icon" class="icon-metadata-container">
                     <i class="fa-solid fa-calendar-days icon-metadata-calendar"></i>
                 </div>
-
             </div>
             <div id="calender_checkbox_container" class="calendar-checkbox-container">
                 {% with %}
@@ -138,6 +138,20 @@
                     {% set checkbox_text_class = "subtitle-1" %}
                     {% set checkbox_label_text = "End Date Same As Start Date" %}
                     {% include "partials/checkbox.html" %}
+                {% endwith %}
+            </div>
+
+            <div id="metadata_start_timezone">
+                {% with %}
+                    {% set dropdown_type = "timezone_dropdown" %}
+                    {% set banner_search_dropdown_class = "banner-dropdown-list-container"%}
+                    {% set container_id = "temporalStartDropdownContainer" %}
+                    {% set dropdown_id = "temporalStartDropdown" %}
+                    {% set dropdown_button_id = "dropdownListTemporalStartButton" %}
+                    {% set dropdown_button_text_id = "dropdownListTemporalStartButtonText" %}
+                    {% set dropdown_default_UL_id = "timezoneStart" %}
+                    {% set dropdown_label_text = "Select Timezone" %}
+                    {% include "partials/dropdown-publish.html" %}
                 {% endwith %}
             </div>
 

--- a/templates/site/publish-dataproduct.html
+++ b/templates/site/publish-dataproduct.html
@@ -149,7 +149,7 @@
                     {% set dropdown_id = "temporalStartDropdown" %}
                     {% set dropdown_button_id = "dropdownListTemporalStartButton" %}
                     {% set dropdown_button_text_id = "dropdownListTemporalStartButtonText" %}
-                    {% set dropdown_default_UL_id = "timezoneStart" %}
+                    {% set dropdown_default_UL_id = "timezoneDropdown" %}
                     {% set dropdown_label_text = "Select Timezone" %}
                     {% include "partials/dropdown-publish.html" %}
                 {% endwith %}


### PR DESCRIPTION
Adds a dropdown to the Temporal section that allows a user  to select a timezone.
The time selected in the calendar is preserved.  (If the user's data is at 3pm in California the return from the server will show 3pm and the timezone dropdown will show GMT-8).

Note that these timezones are GMT centered and the offsets are calculated from Greenwich.

